### PR TITLE
Improve main page load speed for mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "gatsby-plugin-react-helmet": "^2.0.3",
     "react-helmet": "^5.2.0",
     "react-lazyload": "^2.3.0",
+    "react-responsive": "^4.0.4",
     "react-reveal": "^1.0.0",
     "react-scroll": "^1.7.6"
   },

--- a/src/components/Highlights/index.js
+++ b/src/components/Highlights/index.js
@@ -13,7 +13,12 @@ const Highlights = () => (
       }}
     >
       {Array.from(new Array(24), (x, i) => i + 1).map((_, i) => (
-        <LazyLoad key={`highlightImage${i}`} offset={3400} placeholder={<div style={{ width: 300, height: 201.953 }} />} once>
+        <LazyLoad
+          key={`highlightImage${i}`}
+          offset={3400}
+          placeholder={<div style={{ width: 300, height: 201.953 }} />}
+          once
+        >
           <div style={{ flexBasis: 300 }}>
             <img
               src={require(`./images/highlights-${i + 1}@2x.png`)}

--- a/src/components/Speakers/index.js
+++ b/src/components/Speakers/index.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react'
+import MediaQuery from 'react-responsive'
+import classNames from 'classnames'
 import styles from './speakers.module.css'
 import Fade from 'react-reveal/Fade'
 import speakers from './speakers.json'
@@ -15,18 +17,24 @@ class Speaker extends Component {
       <div style={{ textAlign: 'center', width: 250, marginBottom: 50 }}>
         <Fade left>
           <div style={{ position: 'relative', height: 188 }}>
-            <img
-              src={secondaryImgSrc}
-              alt={`${name}'s image`}
-              className={styles['speaker-image']}
-            />
-            <img
-              src={primaryImgSrc}
-              alt={`${name}'s image`}
-              className={`${styles['speaker-image']} ${
-                styles['primary-image']
-              }`}
-            />
+            <MediaQuery minDeviceWidth={1224}>
+              <img
+                src={secondaryImgSrc}
+                alt={`${name}'s image`}
+                className={styles['speaker-image']}
+              />
+            </MediaQuery>
+            <MediaQuery maxDeviceWidth={1224}>
+              {isMobile => (
+                <img
+                  src={primaryImgSrc}
+                  alt={`${name}'s image`}
+                  className={classNames(styles['speaker-image'], {
+                    [styles['primary-image']]: !isMobile,
+                  })}
+                />
+              )}
+            </MediaQuery>
           </div>
         </Fade>
         <h2>{name}</h2>

--- a/src/pages/conference/index.js
+++ b/src/pages/conference/index.js
@@ -28,9 +28,7 @@ class Conference extends Component {
         <div style={{ width: 166, marginBottom: 15 }}>
           <BuyTicketsButton inverse />
         </div>
-        <p style={{ marginBottom: 20 }}>
-          Seating is limited.
-        </p>
+        <p style={{ marginBottom: 20 }}>Seating is limited.</p>
         <ConvinceYourBoss />
       </div>
     )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import MediaQuery from 'react-responsive'
 import Conference from '../components/Conference'
 import Speakers from '../components/Speakers'
 import AdditionalEvents from '../components/AdditionalEvents'
@@ -16,8 +17,12 @@ const IndexPage = () => (
     <hr />
     <AdditionalEvents />
     <hr />
-    <Highlights />
-    <hr />
+    <MediaQuery minDeviceWidth={1224}>
+      <div>
+        <Highlights />
+        <hr />
+      </div>
+    </MediaQuery>
     <Sponsors />
     <hr />
     <BuyTickets />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2016,6 +2016,10 @@ css-loader@^0.26.1:
     postcss-modules-values "^1.1.0"
     source-list-map "^0.1.7"
 
+css-mediaquery@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/css-mediaquery/-/css-mediaquery-0.1.2.tgz#6a2c37344928618631c54bd33cedd301da18bea0"
+
 css-select@^1.1.0, css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -3648,6 +3652,10 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
+hyphenate-style-name@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
+
 iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -4556,6 +4564,12 @@ map-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   dependencies:
     object-visit "^1.0.0"
+
+matchmediaquery@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/matchmediaquery/-/matchmediaquery-0.2.1.tgz#223c7005793de03e47ce92b13285a72c44ada2cf"
+  dependencies:
+    css-mediaquery "^0.1.2"
 
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
@@ -5948,7 +5962,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -6158,6 +6172,14 @@ react-proxy@^3.0.0-alpha.0:
   resolved "https://registry.yarnpkg.com/react-proxy/-/react-proxy-3.0.0-alpha.1.tgz#4400426bcfa80caa6724c7755695315209fa4b07"
   dependencies:
     lodash "^4.6.1"
+
+react-responsive@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/react-responsive/-/react-responsive-4.0.4.tgz#dfeabcbbf180d6e7561562ad9d6d44769e74c43e"
+  dependencies:
+    hyphenate-style-name "^1.0.0"
+    matchmediaquery "^0.2.1"
+    prop-types "^15.0.0"
 
 react-reveal@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Hide highlight and speaker secondary images on mobile devices to speed up main page load as discussed in issue https://github.com/realworldreact/reactathon-2018/issues/38.

Used react-responsive to help with mobile detection. https://github.com/contra/react-responsive