### PR TITLE
Fix big header fade in twice bug

### DIFF
--- a/src/components/BigHeader/index.js
+++ b/src/components/BigHeader/index.js
@@ -9,6 +9,7 @@ import BuyTicketsButton from '../BuyTicketsButton'
 class BigHeader extends Component {
   state = {
     loaded: false,
+    updateCount: 0
   }
 
   componentDidMount() {
@@ -19,6 +20,14 @@ class BigHeader extends Component {
     }
 
     img.src = backgroundImage
+  }
+
+  shouldComponentUpdate() {
+    return this.state.updateCount < 1
+  }
+
+  componentDidUpdate() {
+    this.setState({ updateCount: this.state.updateCount + 1 })
   }
 
   render() {

--- a/src/components/BigHeader/index.js
+++ b/src/components/BigHeader/index.js
@@ -8,8 +8,7 @@ import BuyTicketsButton from '../BuyTicketsButton'
 
 class BigHeader extends Component {
   state = {
-    loaded: false,
-    updateCount: 0
+    loaded: false
   }
 
   componentDidMount() {
@@ -22,12 +21,8 @@ class BigHeader extends Component {
     img.src = backgroundImage
   }
 
-  shouldComponentUpdate() {
-    return this.state.updateCount < 1
-  }
-
-  componentDidUpdate() {
-    this.setState({ updateCount: this.state.updateCount + 1 })
+  shouldComponentUpdate({}, prevState) {
+    return prevState.loaded !== this.state.loaded
   }
 
   render() {

--- a/src/components/BigHeader/index.js
+++ b/src/components/BigHeader/index.js
@@ -8,7 +8,7 @@ import BuyTicketsButton from '../BuyTicketsButton'
 
 class BigHeader extends Component {
   state = {
-    loaded: false
+    loaded: false,
   }
 
   componentDidMount() {


### PR DESCRIPTION
Issue https://github.com/realworldreact/reactathon-2018/issues/37

The big header should only re-render once when the background image has loaded into memory.

Not exactly sure what is causing the big header to fade in twice. Problem only seems to occur when pushing to Netlify. Creating PR to see if preview still occasionally fades in twice.