### PR TITLE
Fix social media meta tags

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,51 @@
+import React from "react"
+
+let stylesStr
+if (process.env.NODE_ENV === `production`) {
+  try {
+    stylesStr = require(`!raw-loader!../public/styles.css`)
+  } catch (e) {
+    console.log(e)
+  }
+}
+
+module.exports = class HTML extends React.Component {
+  render() {
+    let css
+    if (process.env.NODE_ENV === `production`) {
+      css = (
+        <style
+          id="gatsby-inlined-css"
+          dangerouslySetInnerHTML={{ __html: stylesStr }}
+        />
+      )
+    }
+    return (
+      <html {...this.props.htmlAttributes}>
+        <head>
+          <meta charSet="utf-8" />
+          <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+          <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, shrink-to-fit=no"
+          />
+          <meta property="og:title" content="Reactathon: March 19 - 25" />
+          <meta property="og:description" content="3-day dual-conference & hackathon in San Francisco featuring the brightest minds in the JS/React community." />
+          <meta property="og:image" content="https://s3-us-west-1.amazonaws.com/reactathon-2018/reactathon-og-image.png" />
+          <meta property="og:url" content="https://www.reactathon.com" />
+          {this.props.headComponents}
+          {css}
+        </head>
+        <body {...this.props.bodyAttributes}>
+          {this.props.preBodyComponents}
+          <div
+            key={`body`}
+            id="___gatsby"
+            dangerouslySetInnerHTML={{ __html: this.props.body }}
+          />
+          {this.props.postBodyComponents}
+        </body>
+      </html>
+    )
+  }
+}


### PR DESCRIPTION
Twitter is okay with meta tags defined with Helmet, but Facebook and LinkedIn are not. This should hopefully fix the social media tags for all sites.

Linked issues are #40 and #41 